### PR TITLE
Fix some string arguments to Printf()/Error()

### DIFF
--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -1799,7 +1799,7 @@ void idMultiplayerGame::ExecuteVote( void ) {
 				SavePersistentPlayersInfo(); //saving player info in Coop for the next map
 
 				if (nextMap != "") {
-					gameLocal.Printf("Loading next map ", nextMap);
+					gameLocal.Printf("Loading next map %s", nextMap.c_str());
 					si_map.SetString(nextMap);
 					gameLocal.MapRestart();
 				}

--- a/d3xp/ai/AI.cpp
+++ b/d3xp/ai/AI.cpp
@@ -4284,7 +4284,7 @@ void idAI::BeginAttack( const char *name ) {
 	if (attack.Length() && gameLocal.mpGame.IsGametypeCoopBased() && gameLocal.isServer) {
 		const idDeclEntityDef *meleeDef = gameLocal.FindEntityDef( attack, false );
 		if ( !meleeDef ) {
-			gameLocal.Error( "Unknown damage def '%s' on '%s'", attack, this->name.c_str() );
+			gameLocal.Error( "Unknown damage def '%s' on '%s'", attack.c_str(), this->name.c_str() );
 		}
 		currentAttackDefNum = meleeDef->Index();
 	}

--- a/game/MultiplayerGame.cpp
+++ b/game/MultiplayerGame.cpp
@@ -1344,7 +1344,7 @@ void idMultiplayerGame::ExecuteVote( void ) {
 				SavePersistentPlayersInfo(); //saving player info in Coop for the next map
 
 				if (nextMap != "") {
-					gameLocal.Printf("Loading next map ", nextMap);
+					gameLocal.Printf("Loading next map %s", nextMap.c_str());
 					si_map.SetString(nextMap);
 					gameLocal.MapRestart();
 				} else {

--- a/game/ai/AI.cpp
+++ b/game/ai/AI.cpp
@@ -4171,7 +4171,7 @@ void idAI::BeginAttack( const char *name ) {
 	if (attack.Length() && gameLocal.mpGame.IsGametypeCoopBased() && gameLocal.isServer) {
 		const idDeclEntityDef *meleeDef = gameLocal.FindEntityDef( attack, false );
 		if ( !meleeDef ) {
-			gameLocal.Error( "Unknown damage def '%s' on '%s'", attack, this->name.c_str() );
+			gameLocal.Error( "Unknown damage def '%s' on '%s'", attack.c_str(), this->name.c_str() );
 		}
 		currentAttackDefNum = meleeDef->Index();
 	}


### PR DESCRIPTION
%s must be used with (const) char*, no implicit casting is done,
so idStr strings must be used with .c_str()

It might appear to work without it, but if it actually does depends
on the platforms ABI and on whether the idStr uses its internal
baseBuffer or the dynamically allocated "char* data" member.