### PR TITLE
Fix for gamepad support

### DIFF
--- a/d3xp/Player.cpp
+++ b/d3xp/Player.cpp
@@ -5993,6 +5993,11 @@ void idPlayer::UpdateFocus( void ) {
 
 	if ( focusGUIent && focusUI ) {
 		if ( !oldFocus || oldFocus != focusGUIent ) {
+			// DG: tell the old UI it isn't focused anymore
+			if ( oldFocus != NULL && oldUI != NULL ) {
+				command = oldUI->Activate( false, gameLocal.time );
+				// TODO: HandleGuiCommands( oldFocus, command ); ?
+			} // DG end
 			command = focusUI->Activate( true, gameLocal.time );
 			HandleGuiCommands( focusGUIent, command );
 			StartSound( "snd_guienter", SND_CHANNEL_ANY, 0, false, NULL );

--- a/game/Player.cpp
+++ b/game/Player.cpp
@@ -5030,6 +5030,11 @@ void idPlayer::UpdateFocus( void ) {
 
 	if ( focusGUIent && focusUI ) {
 		if ( !oldFocus || oldFocus != focusGUIent ) {
+			// DG: tell the old UI it isn't focused anymore
+			if ( oldFocus != NULL && oldUI != NULL ) {
+				command = oldUI->Activate( false, gameLocal.time );
+				// TODO: HandleGuiCommands( oldFocus, command ); ?
+			} // DG end
 			command = focusUI->Activate( true, gameLocal.time );
 			HandleGuiCommands( focusGUIent, command );
 			StartSound( "snd_guienter", SND_CHANNEL_ANY, 0, false, NULL );


### PR DESCRIPTION
Dhewm3 1.5.3 has gamepad support.
For it to work properly (to emulate mouse) it needs a little change in the game dlls

(the librecoop DLLs I ship in the 1.5.3 dhewm3-mods archives already contain this fix)